### PR TITLE
chore: update Angular dependencies to v21 in both UI workspaces

### DIFF
--- a/Sandbox/SeriMongoUI/package.json
+++ b/Sandbox/SeriMongoUI/package.json
@@ -11,27 +11,27 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "~9.1.11",
-    "@angular/common": "~9.1.11",
-    "@angular/compiler": "~9.1.11",
-    "@angular/core": "~9.1.11",
-    "@angular/forms": "~9.1.11",
-    "@angular/platform-browser": "~9.1.11",
-    "@angular/platform-browser-dynamic": "~9.1.11",
-    "@angular/router": "~9.1.11",
+    "@angular/animations": "^21.2.0",
+    "@angular/common": "^21.2.0",
+    "@angular/compiler": "^21.2.0",
+    "@angular/core": "^21.2.0",
+    "@angular/forms": "^21.2.0",
+    "@angular/platform-browser": "^21.2.0",
+    "@angular/platform-browser-dynamic": "^21.2.0",
+    "@angular/router": "^21.2.0",
     "@microsoft/signalr": "^3.1.5",
-    "rxjs": "~6.5.4",
-    "tslib": "^1.10.0",
-    "zone.js": "~0.10.2"
+    "rxjs": "^7.8.2",
+    "tslib": "^2.8.1",
+    "zone.js": "~0.15.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.901.9",
-    "@angular/cli": "~9.1.9",
-    "@angular/compiler-cli": "~9.1.11",
+    "@angular-devkit/build-angular": "^21.2.0",
+    "@angular/cli": "^21.2.0",
+    "@angular/compiler-cli": "^21.2.0",
     "@angularclass/hmr": "^2.1.3",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
-    "@types/node": "^12.11.1",
+    "@types/node": "^22.10.0",
     "codelyzer": "^5.1.2",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~4.2.1",
@@ -43,6 +43,6 @@
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "~3.8.3"
+    "typescript": "~5.9.3"
   }
 }

--- a/SeriMongo/package.json
+++ b/SeriMongo/package.json
@@ -13,28 +13,28 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "~9.1.11",
-    "@angular/cdk": "^9.2.4",
-    "@angular/common": "~9.1.11",
-    "@angular/compiler": "~9.1.11",
-    "@angular/core": "~9.1.11",
-    "@angular/forms": "~9.1.11",
-    "@angular/platform-browser": "~9.1.11",
-    "@angular/platform-browser-dynamic": "~9.1.11",
-    "@angular/router": "~9.1.11",
+    "@angular/animations": "^21.2.0",
+    "@angular/cdk": "^21.2.0",
+    "@angular/common": "^21.2.0",
+    "@angular/compiler": "^21.2.0",
+    "@angular/core": "^21.2.0",
+    "@angular/forms": "^21.2.0",
+    "@angular/platform-browser": "^21.2.0",
+    "@angular/platform-browser-dynamic": "^21.2.0",
+    "@angular/router": "^21.2.0",
     "@microsoft/signalr": "^3.1.5",
-    "rxjs": "~6.5.4",
-    "tslib": "^1.10.0",
-    "zone.js": "~0.10.2"
+    "rxjs": "^7.8.2",
+    "tslib": "^2.8.1",
+    "zone.js": "~0.15.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.901.9",
-    "@angular/cli": "~9.1.9",
-    "@angular/compiler-cli": "~9.1.11",
+    "@angular-devkit/build-angular": "^21.2.0",
+    "@angular/cli": "^21.2.0",
+    "@angular/compiler-cli": "^21.2.0",
     "@angularclass/hmr": "^2.1.3",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
-    "@types/node": "^12.11.1",
+    "@types/node": "^22.10.0",
     "codelyzer": "^5.1.2",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~4.2.1",
@@ -46,6 +46,6 @@
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "~3.8.3"
+    "typescript": "~5.9.3"
   }
 }


### PR DESCRIPTION
### Motivation
- Bring the UI workspaces up to a modern Angular stable (v21) to obtain security fixes, improved tooling, and compatibility with newer TypeScript and RxJS versions.
- Make both `SeriMongo` and `Sandbox/SeriMongoUI` use aligned dependency ranges so the projects can move forward with consistent build tooling.

### Description
- Bumped Angular framework packages (`@angular/animations`, `@angular/common`, `@angular/compiler`, `@angular/core`, `@angular/forms`, `@angular/platform-browser`, `@angular/platform-browser-dynamic`, `@angular/router`) from v9 to `^21.2.0` in `SeriMongo/package.json` and `Sandbox/SeriMongoUI/package.json`.
- Upgraded Angular tooling (`@angular/cli`, `@angular/compiler-cli`, `@angular-devkit/build-angular`) and `@angular/cdk` to `^21.2.0`.
- Updated runtime/build dependencies to modern compatible releases: `rxjs` -> `^7.8.2`, `tslib` -> `^2.8.1`, `zone.js` -> `~0.15.1`, `typescript` -> `~5.9.3`, and `@types/node` -> `^22.10.0`.
- Only `package.json` files were modified in the two UI workspaces; no application source files were changed in this PR.

### Testing
- Attempted to regenerate the lockfile with `npm install --package-lock-only` in `SeriMongo`, which failed with dependency resolution errors (`ERESOLVE`) due to registry/peer conflicts in this environment.
- Attempted to query the npm registry with `npm view @angular/core` to verify published versions, which failed with a `403` from the registry, preventing automated verification here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ef2adca08330a8f934de112d2079)